### PR TITLE
Fix segfault in amd-fftw by removing dynamic dispatcher

### DIFF
--- a/binfo/020_01_amd_fftw_single_precision.binfo
+++ b/binfo/020_01_amd_fftw_single_precision.binfo
@@ -7,8 +7,5 @@ BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.1
 
 BINFO_APP_CONFIG_CMD_ARRAY=(
     "cd ${BINFO_APP_BUILD_DIR}"
-    "${BINFO_APP_SRC_DIR}/configure -enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-mpi --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-dynamic-dispatcher --enable-single --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
-    "export LDFLAGS=$LDFLAGS_OLD"
-    "export CPPFLAGS=$CPPFLAGS_OLD"
-
+    "${BINFO_APP_SRC_DIR}/configure --enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-mpi --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-single --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
 )

--- a/binfo/020_02_amd_fftw_double_precision.binfo
+++ b/binfo/020_02_amd_fftw_double_precision.binfo
@@ -7,5 +7,5 @@ BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.1
 
 BINFO_APP_CONFIG_CMD_ARRAY=(
     "cd ${BINFO_APP_BUILD_DIR}"
-    "${BINFO_APP_SRC_DIR}/configure -enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-mpi --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-dynamic-dispatcher --enable-double --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
+    "${BINFO_APP_SRC_DIR}/configure --enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-mpi --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
 )

--- a/binfo/020_03_amd_fftw_long_double_precision.binfo
+++ b/binfo/020_03_amd_fftw_long_double_precision.binfo
@@ -7,5 +7,5 @@ BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.1
 
 BINFO_APP_CONFIG_CMD_ARRAY=(
     "cd ${BINFO_APP_BUILD_DIR}"
-    "${BINFO_APP_SRC_DIR}/configure --enable-mpi --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-dynamic-dispatcher --enable-long-double --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
+    "${BINFO_APP_SRC_DIR}/configure --enable-mpi --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-long-double --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
 )

--- a/binfo/020_04_amd_fftw_quad_precision.binfo
+++ b/binfo/020_04_amd_fftw_quad_precision.binfo
@@ -7,5 +7,5 @@ BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.1
 
 BINFO_APP_CONFIG_CMD_ARRAY=(
     "cd ${BINFO_APP_BUILD_DIR}"
-    "${BINFO_APP_SRC_DIR}/configure --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-dynamic-dispatcher --enable-quad-precision --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
+    "${BINFO_APP_SRC_DIR}/configure --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-quad-precision --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
 )


### PR DESCRIPTION
Removes the `--enable-dynamic-dispatcher` flag that results in a library that segfaults on `dlopen()` on at least some versions of Ubuntu and Manjaro. Fixes #74.

Note: this also fixes some typos in the flags (`--enable-sse2`, and `--enable-double` is not a thing as it's the default) and removes two `export` commands which were only present in the build for single precision, the purpose of which is unclear to me. It didn't seem to do anything when I built things, and in any case it makes no sense to have it only there.

This should be considered a stopgap until we figure out the actual impact (in terms of performance/functionality) of removing this flag, if any, but that's covered in #82.